### PR TITLE
Startup and cam fixes

### DIFF
--- a/config/main.c
+++ b/config/main.c
@@ -954,6 +954,8 @@ struct settings {
 
 	int ps2_controls;
 	int ui_controls;
+	int intromovies;
+	int dontinvertoffboardcam;
 };
 
 struct keybinds {
@@ -1118,6 +1120,8 @@ void defaultSettings() {
 	settings.fog = 0;
 	
 	settings.ps2_controls = 1;
+	settings.intromovies = 1;
+	settings.dontinvertoffboardcam = 1;
 
 	keybinds.ollie = SDL_SCANCODE_KP_2;
 	keybinds.grab = SDL_SCANCODE_KP_6;
@@ -1206,6 +1210,8 @@ void loadSettings() {
 
 	settings.ps2_controls = getIniBool("Miscellaneous", "UsePS2Controls", 1, configFile);
 	settings.ui_controls = GetPrivateProfileInt("Miscellaneous", "UIControls", 1, configFile);
+	settings.intromovies = GetPrivateProfileInt("Miscellaneous", "DisplayIntroMovies", 1, configFile);
+	settings.dontinvertoffboardcam = GetPrivateProfileInt("Miscellaneous", "DontInvertOffBoardCamera", 1, configFile);
 
 	keybinds.ollie = GetPrivateProfileInt("Keybinds", "Ollie", SDL_SCANCODE_KP_2, configFile);
 	keybinds.grab = GetPrivateProfileInt("Keybinds", "Grab", SDL_SCANCODE_KP_6, configFile);
@@ -1283,6 +1289,8 @@ void saveSettings() {
 
 	writeIniBool("Miscellaneous", "UsePS2Controls", settings.ps2_controls, configFile);
 	writeIniInt("Miscellaneous", "UIControls", settings.ui_controls, configFile);
+	writeIniInt("Miscellaneous", "DisplayIntroMovies", settings.intromovies, configFile);
+	writeIniInt("Miscellaneous", "DontInvertOffBoardCamera", settings.dontinvertoffboardcam, configFile);
 
 	writeIniInt("Keybinds", "Ollie", keybinds.ollie, configFile);
 	writeIniInt("Keybinds", "Grab", keybinds.grab, configFile);
@@ -1889,6 +1897,8 @@ struct general_page {
 	pgui_control *ps2_controls;
 	pgui_control *ui_controls_label;
 	pgui_control *ui_controls;
+	pgui_control *intromovies;
+	pgui_control *dontinvertoffboardcam;
 };
 
 struct general_page general_page;
@@ -2007,6 +2017,8 @@ void build_general_page(pgui_control *parent) {
 	general_page.ps2_controls = pgui_checkbox_create(8, 16, 128, 24, "Use PS2/360 Controls", misc_groupbox);
 	general_page.ui_controls_label = pgui_label_create(8, 16 + 28, 80, 16, "Menu Controls:", PGUI_LABEL_JUSTIFY_LEFT, misc_groupbox);
 	general_page.ui_controls = pgui_combobox_create(8 + 80, 16 + 24, 80, 24, uicontrol_options, 3, misc_groupbox);
+	general_page.intromovies = pgui_checkbox_create(8, (24 * 2) + 16, 128, 24, "Display Intro Movies", misc_groupbox);
+	general_page.dontinvertoffboardcam = pgui_checkbox_create(8, (24 * 3) + 16, 160, 24, "Don't Invert Offboard Camera", misc_groupbox);
 
 	pgui_checkbox_set_on_toggle(general_page.windowed, do_setting_checkbox, &(settings.windowed));
 	pgui_checkbox_set_on_toggle(general_page.borderless, do_setting_checkbox, &(settings.borderless));
@@ -2019,6 +2031,8 @@ void build_general_page(pgui_control *parent) {
 
 	pgui_checkbox_set_on_toggle(general_page.ps2_controls, do_setting_checkbox, &(settings.ps2_controls));
 	pgui_combobox_set_on_select(general_page.ui_controls, set_menu_combobox, &(settings.ui_controls));
+	pgui_checkbox_set_on_toggle(general_page.intromovies, do_setting_checkbox, &(settings.intromovies));
+	pgui_checkbox_set_on_toggle(general_page.dontinvertoffboardcam, do_setting_checkbox, &(settings.dontinvertoffboardcam));
 
 	pgui_combobox_set_on_select(general_page.resolution_combobox, set_display_mode, NULL);
 	pgui_checkbox_set_on_toggle(general_page.custom_resolution, check_custom_resolution, NULL);
@@ -2095,6 +2109,8 @@ void update_general_page() {
 
 	pgui_checkbox_set_checked(general_page.ps2_controls, settings.ps2_controls);
 	pgui_combobox_set_selection(general_page.ui_controls, settings.ui_controls);
+	pgui_checkbox_set_checked(general_page.intromovies, settings.intromovies);
+	pgui_checkbox_set_checked(general_page.dontinvertoffboardcam, settings.dontinvertoffboardcam);
 }
 
 void callback_ok(pgui_control *control, void *data) {

--- a/config/main.c
+++ b/config/main.c
@@ -955,7 +955,6 @@ struct settings {
 	int ps2_controls;
 	int ui_controls;
 	int intromovies;
-	int dontinvertoffboardcam;
 };
 
 struct keybinds {
@@ -1121,7 +1120,6 @@ void defaultSettings() {
 	
 	settings.ps2_controls = 1;
 	settings.intromovies = 1;
-	settings.dontinvertoffboardcam = 1;
 
 	keybinds.ollie = SDL_SCANCODE_KP_2;
 	keybinds.grab = SDL_SCANCODE_KP_6;
@@ -1211,7 +1209,6 @@ void loadSettings() {
 	settings.ps2_controls = getIniBool("Miscellaneous", "UsePS2Controls", 1, configFile);
 	settings.ui_controls = GetPrivateProfileInt("Miscellaneous", "UIControls", 1, configFile);
 	settings.intromovies = GetPrivateProfileInt("Miscellaneous", "DisplayIntroMovies", 1, configFile);
-	settings.dontinvertoffboardcam = GetPrivateProfileInt("Miscellaneous", "DontInvertOffBoardCamera", 1, configFile);
 
 	keybinds.ollie = GetPrivateProfileInt("Keybinds", "Ollie", SDL_SCANCODE_KP_2, configFile);
 	keybinds.grab = GetPrivateProfileInt("Keybinds", "Grab", SDL_SCANCODE_KP_6, configFile);
@@ -1290,7 +1287,6 @@ void saveSettings() {
 	writeIniBool("Miscellaneous", "UsePS2Controls", settings.ps2_controls, configFile);
 	writeIniInt("Miscellaneous", "UIControls", settings.ui_controls, configFile);
 	writeIniInt("Miscellaneous", "DisplayIntroMovies", settings.intromovies, configFile);
-	writeIniInt("Miscellaneous", "DontInvertOffBoardCamera", settings.dontinvertoffboardcam, configFile);
 
 	writeIniInt("Keybinds", "Ollie", keybinds.ollie, configFile);
 	writeIniInt("Keybinds", "Grab", keybinds.grab, configFile);
@@ -1898,7 +1894,6 @@ struct general_page {
 	pgui_control *ui_controls_label;
 	pgui_control *ui_controls;
 	pgui_control *intromovies;
-	pgui_control *dontinvertoffboardcam;
 };
 
 struct general_page general_page;
@@ -2018,7 +2013,6 @@ void build_general_page(pgui_control *parent) {
 	general_page.ui_controls_label = pgui_label_create(8, 16 + 28, 80, 16, "Menu Controls:", PGUI_LABEL_JUSTIFY_LEFT, misc_groupbox);
 	general_page.ui_controls = pgui_combobox_create(8 + 80, 16 + 24, 80, 24, uicontrol_options, 3, misc_groupbox);
 	general_page.intromovies = pgui_checkbox_create(8, (24 * 2) + 16, 128, 24, "Display Intro Movies", misc_groupbox);
-	general_page.dontinvertoffboardcam = pgui_checkbox_create(8, (24 * 3) + 16, 160, 24, "Don't Invert Offboard Camera", misc_groupbox);
 
 	pgui_checkbox_set_on_toggle(general_page.windowed, do_setting_checkbox, &(settings.windowed));
 	pgui_checkbox_set_on_toggle(general_page.borderless, do_setting_checkbox, &(settings.borderless));
@@ -2032,7 +2026,6 @@ void build_general_page(pgui_control *parent) {
 	pgui_checkbox_set_on_toggle(general_page.ps2_controls, do_setting_checkbox, &(settings.ps2_controls));
 	pgui_combobox_set_on_select(general_page.ui_controls, set_menu_combobox, &(settings.ui_controls));
 	pgui_checkbox_set_on_toggle(general_page.intromovies, do_setting_checkbox, &(settings.intromovies));
-	pgui_checkbox_set_on_toggle(general_page.dontinvertoffboardcam, do_setting_checkbox, &(settings.dontinvertoffboardcam));
 
 	pgui_combobox_set_on_select(general_page.resolution_combobox, set_display_mode, NULL);
 	pgui_checkbox_set_on_toggle(general_page.custom_resolution, check_custom_resolution, NULL);
@@ -2110,7 +2103,6 @@ void update_general_page() {
 	pgui_checkbox_set_checked(general_page.ps2_controls, settings.ps2_controls);
 	pgui_combobox_set_selection(general_page.ui_controls, settings.ui_controls);
 	pgui_checkbox_set_checked(general_page.intromovies, settings.intromovies);
-	pgui_checkbox_set_checked(general_page.dontinvertoffboardcam, settings.dontinvertoffboardcam);
 }
 
 void callback_ok(pgui_control *control, void *data) {

--- a/partymod.ini
+++ b/partymod.ini
@@ -13,6 +13,8 @@ Fog=0
 Debug=1	; enables debug output that can help troubleshoot controllers
 UsePS2Controls=1
 UIControls=1 ; the displayed controls as well as the menu/dialog controls.  0 = Xbox/PC, 1 = 360/Xenon, 2 = PS2
+DisplayIntroMovies=1
+DontInvertOffBoardCamera=1
 
 ; keybinds use SDL_Scancode values.  the partyconfig utility allows for better control over these
 [Keybinds]

--- a/partymod.ini
+++ b/partymod.ini
@@ -14,7 +14,6 @@ Debug=1	; enables debug output that can help troubleshoot controllers
 UsePS2Controls=1
 UIControls=1 ; the displayed controls as well as the menu/dialog controls.  0 = Xbox/PC, 1 = 360/Xenon, 2 = PS2
 DisplayIntroMovies=1
-DontInvertOffBoardCamera=1
 
 ; keybinds use SDL_Scancode values.  the partyconfig utility allows for better control over these
 [Keybinds]

--- a/src/main.c
+++ b/src/main.c
@@ -28,7 +28,6 @@ uint32_t addr_camera_lookat;
 uint32_t addr_aspyr_debug;
 uint32_t addr_aspyr_debug_skip_jump;
 uint32_t addr_their_PlayMovie;
-uint32_t addr_invertoffboardcam;
 
 uint8_t get_misc_offsets() {
 	uint8_t *shuffleAnchor = NULL;
@@ -38,7 +37,6 @@ uint8_t get_misc_offsets() {
 	result &= patch_cache_pattern("f3 0f 5c cc f3 0f 5c d5 f3 0f 5c de 68", &addr_camera_lookat);
 	result &= patch_cache_pattern("?? ?? ?? ?? 00 00 8A 44 24 1B 84 C0", &addr_aspyr_debug_skip_jump);
 	result &= patch_cache_pattern("3D 00 08 00 00 89 44 24 20", &addr_aspyr_debug);
-	result &= patch_cache_pattern("F3 0F 59 C1 F3 0F 11 44 24 20 74 0A", &addr_invertoffboardcam);
 
 	if (result) {
 		addr_origrand = *(uint32_t *)(shuffleAnchor + 2) + shuffleAnchor + 6;
@@ -217,12 +215,6 @@ void patchStartupSpeed() {
 	patchJmp((void*)addr_aspyr_debug_skip_jump, (void*)(addr_aspyr_debug-5));	// Jump past entire check. Fail.
 }
 
-void patchOffboardCamera() {
-	if (!getIniBool("Miscellaneous", "DontInvertOffBoardCamera", 1, configFile)) {
-		patchNop((void*)addr_invertoffboardcam, 4);
-	}
-}
-
 void installPatches() {
 	patchWindow();
 	patchInput();
@@ -230,7 +222,6 @@ void installPatches() {
 	patchCamera();
 	patchStartupSpeed();
 	patchIntroMovies();
-	patchOffboardCamera();
 	printf("installing script patches\n");
 	patchScriptHook();
 	printf("done\n");

--- a/src/script.h
+++ b/src/script.h
@@ -7,4 +7,5 @@ void initScriptPatches();
 void registerPS2ControlPatch();
 void setMenuControls(uint8_t value);
 
+uint8_t wrap_cfunc(char* name, void* wrapper, void** addr_out);
 #endif


### PR DESCRIPTION
Remove mad.bik bugging from Aspyr which increases startup time
Add toggle for intro movies, wrap PlayMovie Cfunc to check for startup script
Add toggle for offboard cam inversion
Add entries for new settings in ini and launcher